### PR TITLE
fix: scope npmrc for redhat packages

### DIFF
--- a/charts/backstage/templates/dynamic-plugins-npmrc.yaml
+++ b/charts/backstage/templates/dynamic-plugins-npmrc.yaml
@@ -3,5 +3,5 @@ apiVersion: v1
 metadata:
   name: dynamic-plugins-npmrc
 stringData:
-  .npmrc: registry=https://npm.registry.redhat.com
+  .npmrc: '@redhat:registry=https://npm.registry.redhat.com'
 type: Opaque


### PR DESCRIPTION
It's not possible to install other scoped packages without this change, e.g. @ backstage scoped packages will fail to install if someone tries to add them in the plugins configuration.