### PR TITLE
feat: configure rbac plugin for demos

### DIFF
--- a/charts/backstage/backstage-rhtap-values.yaml
+++ b/charts/backstage/backstage-rhtap-values.yaml
@@ -54,6 +54,8 @@ global:
         disabled: false
       - package: ./dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic
         disabled: false
+      - package: ./dynamic-plugins/dist/janus-idp-backstage-plugin-rbac
+        disabled: false
 {% if jenkins_enabled %}
       - package: ./dynamic-plugins/dist/backstage-plugin-jenkins-backend-dynamic
         disabled: false
@@ -384,6 +386,11 @@ upstream:
 
       permission:
         enabled: false
+        rbac:
+          admin:
+            users:
+              - name: user:default/pe
+
 
       enabled:
         kubernetes: true

--- a/charts/backstage/backstage-values.yaml
+++ b/charts/backstage/backstage-values.yaml
@@ -49,6 +49,8 @@ global:
         disabled: false
       - package: ./dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic
         disabled: false
+      - package: ./dynamic-plugins/dist/janus-idp-backstage-plugin-rbac
+        disabled: false
       - package: ./dynamic-plugins/dist/backstage-plugin-techdocs
         disabled: false
       - package: ./dynamic-plugins/dist/janus-idp-backstage-plugin-tekton
@@ -364,6 +366,10 @@ upstream:
 
       permission:
         enabled: false
+        rbac:
+          admin:
+            users:
+              - name: user:default/pe
 
       enabled:
         kubernetes: true


### PR DESCRIPTION
Linked to https://github.com/redhat-gpte-devopsautomation/software-templates/pull/16, and https://github.com/redhat-gpte-devopsautomation/agnosticg/pull/5.

This prepares the RHDH environment for RBAC demos, should someone wish to perform one.